### PR TITLE
fix: add type ICasts in return of getInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export class Vizer {
                         name: $(elem).find('span').text().trim(),
                         picture: 'https://vizer.tv/' + $(elem).find('img').attr('src') || null
                     }
-                }).toArray() || null,
+                }).toArray() as ICasts[] || null,
                 description: $('#ms > div:nth-child(1) > section > span').text().trim() || null,
             }
         }


### PR DESCRIPTION
After installing lib, the typescript validator detect this error:

![image](https://user-images.githubusercontent.com/13739343/186278226-00ce708f-b70d-43b6-9802-b2183762e703.png)

I swap the Element[] return to ICasts[] to solve it.